### PR TITLE
Add wildcard support to RPS.publish channels

### DIFF
--- a/messenger.js
+++ b/messenger.js
@@ -1,61 +1,62 @@
 /**
  * Match a wildcard rule against and input string.
  *
- *    "a*b"  => everything that starts with "a" and ends with "b"
- "    a*"    => everything that starts with "a"
- "    *b"    => everything that ends with "b"
- "    *a*"   => everything that has a "a" in it
- "    *a*b*" => everything that has a "a" in it, followed by anything, followed by a "b", followed by anything
+ *   "a*b"  => everything that starts with "a" and ends with "b"
+ "   a*"    => everything that starts with "a"
+ "   *b"    => everything that ends with "b"
+ "   *a*"   => everything that has a "a" in it
+ "   *a*b*" => everything that has a "a" in it, followed by anything, followed by a "b", followed by anything
+
  * @param str - The full string to be matched against, e.g. my::channel::value
  * @param rule - A string to match with, which can include wildcards, e.g. my::channel::*
  * @returns {boolean}
  * @private
  */
 RPS._matchRuleShort = function(str, rule) {
-  return new RegExp("^" + rule.replace("*", ".*") + "$").test(str);
+    return new RegExp("^" + rule.replace("*", ".*") + "$").test(str);
 };
 
 RPS._messenger = {
-  channels: {},
-  observers: {},
-  addObserver: function (observerKey, channel) {
-    //console.log('RPS._messenger.addObserver; observerKey, channel:', observerKey, channel);
-    if (!RPS._messenger.channels[channel]) {
-      //console.log('RPS._messenger.addObserver → add channel; channel:', channel);
-      RPS._messenger.channels[channel] = {};
-    }
+    channels: {},
+    observers: {},
+    addObserver: function (observerKey, channel) {
+        //console.log('RPS._messenger.addObserver; observerKey, channel:', observerKey, channel);
+        if (!RPS._messenger.channels[channel]) {
+            //console.log('RPS._messenger.addObserver → add channel; channel:', channel);
+            RPS._messenger.channels[channel] = {};
+        }
 
-    RPS._messenger.channels[channel][observerKey] = true;
-    RPS._messenger.observers[observerKey] = channel;
+        RPS._messenger.channels[channel][observerKey] = true;
+        RPS._messenger.observers[observerKey] = channel;
 
-    RPS._sub(channel);
-  },
-  removeObserver: function (observerKey) {
-    //console.log('RPS._messenger.removeObserver; observerKey:', observerKey);
-    var channel = RPS._messenger.observers[observerKey];
-    if (channel) {
-      delete RPS._messenger.channels[channel][observerKey];
-      if (_.isEmpty(RPS._messenger.channels[channel])) {
-        //console.log('RPS._messenger.removeObserver → remove channel; channel:', channel);
-        RPS._unsub(channel);
-        delete RPS._messenger.channels[channel];
-      }
-    }
-    delete RPS._messenger.observers[observerKey];
-  },
-  onMessage: function (channel, message) {
-    //console.log('RPS._messenger.onMessage; channel, message:', channel, message);
-    var channels = Object.keys(RPS._messenger.channels);
-    _.each(channels, function (openChannel, idx) {
-      //Support wildcard matching for open channels.
-      if (RPS._matchRuleShort(channel, openChannel)) {
-        _.each(RPS._messenger.channels[openChannel], function (flag, observerKey) {
-          var observer = RPS._observers[observerKey];
-          if (observer) {
-            observer.onMessage(EJSON.clone(message));
-          }
+        RPS._sub(channel);
+    },
+    removeObserver: function (observerKey) {
+        //console.log('RPS._messenger.removeObserver; observerKey:', observerKey);
+        var channel = RPS._messenger.observers[observerKey];
+        if (channel) {
+            delete RPS._messenger.channels[channel][observerKey];
+            if (_.isEmpty(RPS._messenger.channels[channel])) {
+                //console.log('RPS._messenger.removeObserver → remove channel; channel:', channel);
+                RPS._unsub(channel);
+                delete RPS._messenger.channels[channel];
+            }
+        }
+        delete RPS._messenger.observers[observerKey];
+    },
+    onMessage: function (channel, message) {
+        //console.log('RPS._messenger.onMessage; channel, message:', channel, message);
+        var channels = Object.keys(RPS._messenger.channels);
+        _.each(channels, function (openChannel, idx) {
+            //Support wildcard matching for open channels.
+            if (RPS._matchRuleShort(channel, openChannel)) {
+                _.each(RPS._messenger.channels[openChannel], function (flag, observerKey) {
+                    var observer = RPS._observers[observerKey];
+                    if (observer) {
+                        observer.onMessage(EJSON.clone(message));
+                    }
+                });
+            }
         });
-      }
-    });
-  }
+    }
 };

--- a/messenger.js
+++ b/messenger.js
@@ -1,38 +1,61 @@
+/**
+ * Match a wildcard rule against and input string.
+ *
+ *    "a*b"  => everything that starts with "a" and ends with "b"
+ "    a*"    => everything that starts with "a"
+ "    *b"    => everything that ends with "b"
+ "    *a*"   => everything that has a "a" in it
+ "    *a*b*" => everything that has a "a" in it, followed by anything, followed by a "b", followed by anything
+ * @param str - The full string to be matched against, e.g. my::channel::value
+ * @param rule - A string to match with, which can include wildcards, e.g. my::channel::*
+ * @returns {boolean}
+ * @private
+ */
+RPS._matchRuleShort = function(str, rule) {
+  return new RegExp("^" + rule.replace("*", ".*") + "$").test(str);
+};
+
 RPS._messenger = {
-    channels: {},
-    observers: {},
-    addObserver: function (observerKey, channel) {
-        //console.log('RPS._messenger.addObserver; observerKey, channel:', observerKey, channel);
-        if (!RPS._messenger.channels[channel]) {
-            //console.log('RPS._messenger.addObserver → add channel; channel:', channel);
-            RPS._messenger.channels[channel] = {};
-        }
-
-        RPS._messenger.channels[channel][observerKey] = true;
-        RPS._messenger.observers[observerKey] = channel;
-
-        RPS._sub(channel);
-    },
-    removeObserver: function (observerKey) {
-        //console.log('RPS._messenger.removeObserver; observerKey:', observerKey);
-        var channel = RPS._messenger.observers[observerKey];
-        if (channel) {
-            delete RPS._messenger.channels[channel][observerKey];
-            if (_.isEmpty(RPS._messenger.channels[channel])) {
-                //console.log('RPS._messenger.removeObserver → remove channel; channel:', channel);
-                RPS._unsub(channel);
-                delete RPS._messenger.channels[channel];
-            }
-        }
-        delete RPS._messenger.observers[observerKey];
-    },
-    onMessage: function (channel, message) {
-        //console.log('RPS._messenger.onMessage; channel, message:', channel, message);
-        _.each(RPS._messenger.channels[channel], function (flag, observerKey) {
-            var observer = RPS._observers[observerKey];
-            if (observer) {
-                observer.onMessage(EJSON.clone(message));
-            }
-        });
+  channels: {},
+  observers: {},
+  addObserver: function (observerKey, channel) {
+    //console.log('RPS._messenger.addObserver; observerKey, channel:', observerKey, channel);
+    if (!RPS._messenger.channels[channel]) {
+      //console.log('RPS._messenger.addObserver → add channel; channel:', channel);
+      RPS._messenger.channels[channel] = {};
     }
+
+    RPS._messenger.channels[channel][observerKey] = true;
+    RPS._messenger.observers[observerKey] = channel;
+
+    RPS._sub(channel);
+  },
+  removeObserver: function (observerKey) {
+    //console.log('RPS._messenger.removeObserver; observerKey:', observerKey);
+    var channel = RPS._messenger.observers[observerKey];
+    if (channel) {
+      delete RPS._messenger.channels[channel][observerKey];
+      if (_.isEmpty(RPS._messenger.channels[channel])) {
+        //console.log('RPS._messenger.removeObserver → remove channel; channel:', channel);
+        RPS._unsub(channel);
+        delete RPS._messenger.channels[channel];
+      }
+    }
+    delete RPS._messenger.observers[observerKey];
+  },
+  onMessage: function (channel, message) {
+    //console.log('RPS._messenger.onMessage; channel, message:', channel, message);
+    var channels = Object.keys(RPS._messenger.channels);
+    _.each(channels, function (openChannel, idx) {
+      //Support wildcard matching for open channels.
+      if (RPS._matchRuleShort(channel, openChannel)) {
+        _.each(RPS._messenger.channels[openChannel], function (flag, observerKey) {
+          var observer = RPS._observers[observerKey];
+          if (observer) {
+            observer.onMessage(EJSON.clone(message));
+          }
+        });
+      }
+    });
+  }
 };

--- a/messenger.js
+++ b/messenger.js
@@ -13,7 +13,7 @@
  * @private
  */
 RPS._matchRuleShort = function(str, rule) {
-    return new RegExp("^" + rule.replace("*", ".*") + "$").test(str);
+    return new RegExp("^" + rule.replace(/\*/g, ".*") + "$").test(str);
 };
 
 RPS._messenger = {

--- a/observe-changes.js
+++ b/observe-changes.js
@@ -153,6 +153,11 @@ RPS._observer.prototype.handleMessage = function (message, noPause) {
     //if (badTS) {
     //    console.warn('RPS: RACE CONDITION! Don’t worry will fix it');
     //}
+    
+    //If a message skips Mongo, it wont have any ID, yet the routien that follows relies on it. Forcing the issue for now.
+    if (message.withoutMongo && !message.id) {
+        message.id = message.ts + message._serverId;
+    }
 
     //console.log('RPS._observer.handleMessage; message, this.selector:', message, this.selector);
     var rightIds = this.needToFetchAlways && _.pluck(this.collection.find(this.selector, this.quickFindOptions).fetch(), '_id'),

--- a/package.js
+++ b/package.js
@@ -4,7 +4,7 @@ Package.describe({
   // Brief, one-line summary of the package.
   summary: 'Custom pub/sub interface for Meteor on top of Redis',
   // URL to the Git repository containing the source code for this package.
-  git: 'https://github.com/chatr/redpubsub.git',
+  git: 'https://github.com/ggn06awu/redpubsub.git',
   // By default, Meteor will default to using README.md for documentation.
   // To avoid submitting documentation, set this field to null.
   documentation: 'README.md'

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: 'chatra:redpubsub',
+  name: 'beeby:redpubsub',
   version: '0.8.6',
   // Brief, one-line summary of the package.
   summary: 'Custom pub/sub interface for Meteor on top of Redis',


### PR DESCRIPTION
We wanted to listen on channels using wildcards, so I have added that code to your messenger as I believe it should work. Would you please consider this and add if you're happy? Example usage:

``` javascript
RPS.publish(this, {
      collection: Comments,
      options: {
        selector: {contextId: contextId},
        channel: 'comments::' + contextId + '::*'
      }
    });
```
